### PR TITLE
Prevent Bees From Suffocating

### DIFF
--- a/src/main/java/tech/techsmp/core/Listeners/EntityHurtListener.java
+++ b/src/main/java/tech/techsmp/core/Listeners/EntityHurtListener.java
@@ -20,11 +20,7 @@ public class EntityHurtListener implements Listener {
 	public void BeeDamaged(EntityDamageEvent event) {
 		if(event.getEntityType() == EntityType.BEE) {
 			if(event.getCause() == EntityDamageEvent.DamageCause.SUFFOCATION) {
-				Entity damagedEntity = event.getEntity();
-				Block blockAtDamageLocation = damagedEntity.getWorld().getBlockAt(damagedEntity.getLocation());
-				if(blockAtDamageLocation.getType() == Material.BEEHIVE || blockAtDamageLocation.getType() == Material.BEE_NEST) {
-					event.setCancelled(true);
-				}
+				event.setCancelled(true);
 			}
 		}
 	}

--- a/src/main/java/tech/techsmp/core/Listeners/EntityHurtListener.java
+++ b/src/main/java/tech/techsmp/core/Listeners/EntityHurtListener.java
@@ -1,0 +1,31 @@
+package tech.techsmp.core.Listeners;
+
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByBlockEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import java.util.ArrayList;
+
+
+public class EntityHurtListener implements Listener {
+	@EventHandler
+	public void BeeDamaged(EntityDamageEvent event) {
+		if(event.getEntityType() == EntityType.BEE) {
+			if(event.getCause() == EntityDamageEvent.DamageCause.SUFFOCATION) {
+				Entity damagedEntity = event.getEntity();
+				Block blockAtDamageLocation = damagedEntity.getWorld().getBlockAt(damagedEntity.getLocation());
+				if(blockAtDamageLocation.getType() == Material.BEEHIVE || blockAtDamageLocation.getType() == Material.BEE_NEST) {
+					event.setCancelled(true);
+				}
+			}
+		}
+	}
+}

--- a/src/main/java/tech/techsmp/core/Main.java
+++ b/src/main/java/tech/techsmp/core/Main.java
@@ -28,9 +28,9 @@ import org.bukkit.inventory.ShapedRecipe;
 
 public class Main extends JavaPlugin implements Listener{
     public ProtocolManager pm;
-        static Main plugin;
-	public void onEnable(){
-                plugin = this;
+    static Main plugin;
+    public void onEnable(){
+        plugin = this;
         Bukkit.getLogger().info("TechSMP By James Jones");
         Bukkit.getServer().getPluginManager().registerEvents(new Chat(), this);
         Bukkit.getServer().getPluginManager().registerEvents(new PlayerDeath(), this);
@@ -46,6 +46,7 @@ public class Main extends JavaPlugin implements Listener{
         Bukkit.getServer().getPluginManager().registerEvents(new TabCompleter(), this);
         Bukkit.getServer().getPluginManager().registerEvents(new GuiListener(), this);
         Bukkit.getServer().getPluginManager().registerEvents(new ArmorStandListener(), this);
+        Bukkit.getServer().getPluginManager().registerEvents(new EntityHurtListener(), this);
         Bukkit.getServer().getPluginManager().registerEvents(new PhantomSpawn(), this);
 
 
@@ -70,7 +71,7 @@ public class Main extends JavaPlugin implements Listener{
         getCommand("inspect").setExecutor(new Inspect(this));
         getCommand("tban").setExecutor(new Tban());
         getCommand("rank").setExecutor(new Rank(this));
-        
+
         ItemStack membrane = new ItemStack(Material.PHANTOM_MEMBRANE);
         ShapedRecipe membraneRecipe = new ShapedRecipe(membrane);
         membraneRecipe.shape("FC","SN");
@@ -78,10 +79,10 @@ public class Main extends JavaPlugin implements Listener{
         membraneRecipe.setIngredient('C', Material.CHORUS_FRUIT);
         membraneRecipe.setIngredient('S', Material.STRING);
         getServer().addRecipe(membraneRecipe);
-        
+
     }
     public static Main getInstance(){
         return plugin;
-     }
-    
+    }
+
 }


### PR DESCRIPTION
All this does is cancel suffocation events for bees. This is to help users who wanted to just... have bees but ran into issues with the suffocating to death inside their own hives. It had a check for specifically beehives and bee nests, but that check failed sometimes and bees have low health, so as a quick fix i removed that check and bees simply cannot suffocate inside of blocks.